### PR TITLE
Fix manifest color extraction

### DIFF
--- a/manifestGenerator.ts
+++ b/manifestGenerator.ts
@@ -9,10 +9,10 @@ export async function GenerateManifest() {
     const scssContent = await fs.readFile('src/assets/_colours.scss', 'utf8');
 
     // Extract colour values
-    const colours = {
-      primaryColour: ExtractColour(scssContent, 'primary-1', '#ffffff'),
-      whiteColour: ExtractColour(scssContent, 'white', '#000000'),
-    };
+  const colours = {
+    primaryColour: ExtractColour(scssContent, 'primary-1', '#ffffff'),
+    whiteColour: ExtractColour(scssContent, 'white', '#000000'),
+  };
 
     // Read and compile manifest template
     const manifestTemplate = await fs.readFile('manifest.hbs', 'utf8');
@@ -33,8 +33,27 @@ function ExtractColour(
   varName: string,
   defaultColour: string,
 ): string {
-  const match = content.match(
-    new RegExp(`\\$${varName}:\\s*(#[0-9a-fA-F]{6});`),
-  );
-  return match ? match[1] : defaultColour;
+  // First try a simple variable match e.g. $white: #fff;
+  const simpleRegex = new RegExp(`\\$${varName}:\\s*(#[0-9a-fA-F]{3,6})`, 'm');
+  let match = content.match(simpleRegex);
+  if (match) {
+    return match[1];
+  }
+
+  // Support SCSS maps e.g. $primary: (1: #4a90e2, ...);
+  const mapParts = varName.split('-');
+  if (mapParts.length === 2) {
+    const [mapName, key] = mapParts;
+    const mapRegex = new RegExp(`\\$${mapName}\\s*:\\s*\\(([^\\)]*)\\)`, 'm');
+    const mapMatch = content.match(mapRegex);
+    if (mapMatch) {
+      const entryRegex = new RegExp(`${key}:\\s*(#[0-9a-fA-F]{3,6})`, 'm');
+      const entryMatch = mapMatch[1].match(entryRegex);
+      if (entryMatch) {
+        return entryMatch[1];
+      }
+    }
+  }
+
+  return defaultColour;
 }


### PR DESCRIPTION
## Summary
- handle SCSS maps when extracting colours for the web manifest

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684c25efe98c83309446955101d59427